### PR TITLE
feat(Tokenization): Add a simple Tokenization

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">=12 <15"
   },
   "dependencies": {
+    "lodash": "^4.17.21",
     "react-wordcloud": "^1.2.3"
   }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,6 +4,11 @@ import { SimplePanel } from './SimplePanel';
 
 export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOptions(builder => {
   return builder
+    .addBooleanSwitch({
+      path: 'tokenization',
+      name: 'Tokenization',
+      description: 'Count the words for you',
+    })
     .addTextInput({
       path: 'datasource_count_field',
       name: 'Count Field',

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface WordCloudOptions {
 
 export interface SimpleOptions {
   wordCloudOptions: WordCloudOptions;
+  tokenization: boolean;
   datasource_tags_field: string;
   datasource_count_field: string;
   series_index: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8463,7 +8463,7 @@ lodash@4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-lodash@4.17.21, lodash@^4.17.19:
+lodash@4.17.21, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
### Tokenization 

#### Why add this
- The current implementation need we split and count the words, in the data source; which may be a burden for some case, for example the storage doesn't support this kind of manipulation or doesn't want to feed too much data into storage
- So we like to add the tokenization in the visualisation layer

#### How to use
- Feed in the data as before
- Enable 'Tokenization' switch

<img width="1820" alt="en-US 25" src="https://user-images.githubusercontent.com/2640513/211310071-96202582-eca2-4e61-9e0a-fa1902368bee.png">
